### PR TITLE
Support `Match` and `Include` blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+## unreleased
+
+### Added
+
+* `SshSection` to switch between different kinds of SSH sections. ([#3], [#4])
+
+### Changes
+
+* ***Breaking:*** `SshHostConfig` renamed to `SshSectionConfig`.
+* ***Breaking:*** `SshConfig` stores `IndexMap<SshSection, _>` instead of `IndexMap<String, _>`.
+* ***Breaking:*** `Error::SshOptionBeforeHost` renamed to `Error::SshOptionBeforeHostOrMatch`.
+
+[#3]: https://github.com/azriel91/ssh_cfg/issues/3
+[#4]: https://github.com/azriel91/ssh_cfg/pull/4
+
+
+## 0.3.0
+
+### Added
+
+* Support parsing SSH configuration files with only `Host` configurations.
+

--- a/src/config_error.rs
+++ b/src/config_error.rs
@@ -6,7 +6,7 @@ use crate::SshOptionKey;
 #[derive(Debug)]
 pub enum ConfigError {
     /// An SSH option is provided before the `Host` key.
-    SshOptionBeforeHost {
+    SshOptionBeforeHostOrMatch {
         /// The SSH option.
         option: SshOptionKey,
         /// Value provided to the key.
@@ -27,10 +27,10 @@ pub enum ConfigError {
 impl fmt::Display for ConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::SshOptionBeforeHost { option, .. } => {
+            Self::SshOptionBeforeHostOrMatch { option, .. } => {
                 write!(
                     f,
-                    "SSH option `{option}` provided before `Host` is specified.",
+                    "SSH option `{option}` provided before `Host` or `Match` is specified.",
                 )
             }
             Self::SshOptionUnknown { key } => {
@@ -48,7 +48,7 @@ impl fmt::Display for ConfigError {
 impl std::error::Error for ConfigError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            Self::SshOptionBeforeHost { .. } => None,
+            Self::SshOptionBeforeHostOrMatch { .. } => None,
             Self::SshOptionUnknown { .. } => None,
             Self::KeyValueNotFound { .. } => None,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,13 +37,14 @@
 
 pub use crate::{
     config_error::ConfigError, error::Error, ssh_config::SshConfig,
-    ssh_config_parser::SshConfigParser, ssh_host_config::SshHostConfig,
-    ssh_option_key::SshOptionKey,
+    ssh_config_parser::SshConfigParser, ssh_option_key::SshOptionKey, ssh_section::SshSection,
+    ssh_section_config::SshSectionConfig,
 };
 
 mod config_error;
 mod error;
 mod ssh_config;
 mod ssh_config_parser;
-mod ssh_host_config;
 mod ssh_option_key;
+mod ssh_section;
+mod ssh_section_config;

--- a/src/ssh_config.rs
+++ b/src/ssh_config.rs
@@ -5,7 +5,7 @@ use indexmap::IndexMap;
 use crate::{SshSection, SshSectionConfig};
 
 /// Parsed SSH config file.
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct SshConfig(pub IndexMap<SshSection, SshSectionConfig>);
 
 impl Deref for SshConfig {

--- a/src/ssh_config.rs
+++ b/src/ssh_config.rs
@@ -2,14 +2,14 @@ use std::ops::{Deref, DerefMut};
 
 use indexmap::IndexMap;
 
-use crate::SshHostConfig;
+use crate::{SshSection, SshSectionConfig};
 
 /// Parsed SSH config file.
 #[derive(Clone, Debug, Default, PartialEq)]
-pub struct SshConfig(pub IndexMap<String, SshHostConfig>);
+pub struct SshConfig(pub IndexMap<SshSection, SshSectionConfig>);
 
 impl Deref for SshConfig {
-    type Target = IndexMap<String, SshHostConfig>;
+    type Target = IndexMap<SshSection, SshSectionConfig>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/src/ssh_section.rs
+++ b/src/ssh_section.rs
@@ -14,9 +14,9 @@ pub enum SshSection {
 impl fmt::Display for SshSection {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Host(host) => write!(f, "Host {}", host),
-            Self::Match(r#match) => write!(f, "Match {}", r#match),
-            Self::Include(include) => write!(f, "Include {}", include),
+            Self::Host(host) => write!(f, "Host {host}"),
+            Self::Match(r#match) => write!(f, "Match {match}"),
+            Self::Include(include) => write!(f, "Include {include}"),
         }
     }
 }

--- a/src/ssh_section.rs
+++ b/src/ssh_section.rs
@@ -1,0 +1,22 @@
+use std::fmt;
+
+/// SSH configuration blocks
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum SshSection {
+    /// `Host` configuration.
+    Host(String),
+    /// `Match` configuration.
+    Match(String),
+    /// Top level include.
+    Include(String),
+}
+
+impl fmt::Display for SshSection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Host(host) => write!(f, "Host {}", host),
+            Self::Match(r#match) => write!(f, "Match {}", r#match),
+            Self::Include(include) => write!(f, "Include {}", include),
+        }
+    }
+}

--- a/src/ssh_section_config.rs
+++ b/src/ssh_section_config.rs
@@ -5,7 +5,7 @@ use indexmap::IndexMap;
 use crate::SshOptionKey;
 
 /// Keys for a particular SSH section.
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct SshSectionConfig(pub IndexMap<SshOptionKey, String>);
 
 impl Deref for SshSectionConfig {

--- a/src/ssh_section_config.rs
+++ b/src/ssh_section_config.rs
@@ -4,11 +4,11 @@ use indexmap::IndexMap;
 
 use crate::SshOptionKey;
 
-/// Keys for a particular SSH host.
+/// Keys for a particular SSH section.
 #[derive(Clone, Debug, Default, PartialEq)]
-pub struct SshHostConfig(pub IndexMap<SshOptionKey, String>);
+pub struct SshSectionConfig(pub IndexMap<SshOptionKey, String>);
 
-impl Deref for SshHostConfig {
+impl Deref for SshSectionConfig {
     type Target = IndexMap<SshOptionKey, String>;
 
     fn deref(&self) -> &Self::Target {
@@ -16,7 +16,7 @@ impl Deref for SshHostConfig {
     }
 }
 
-impl DerefMut for SshHostConfig {
+impl DerefMut for SshSectionConfig {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }


### PR DESCRIPTION
Addresses #3.

Heya @mplinuxgeek, @gfriloux, could you test if it suits your use case. Otherwise feel free to build on top of the branch.

I haven't got much time to maintain this, but one basic improvement is to store a list of Host/Match/Include strings instead of keeping them as a single string.
